### PR TITLE
fixed syntax hilighting inside typscript blocks in tsx

### DIFF
--- a/after/syntax/tsx.vim
+++ b/after/syntax/tsx.vim
@@ -17,17 +17,20 @@ if exists('s:current_syntax')
   let b:current_syntax=s:current_syntax
 endif
 
-syn region tsxRegion contains=@XMLSyntax,tsxRegion,typescriptBlock
-  \ start=+\%(<\|\w\)\@<!<\z([a-zA-Z][a-zA-Z0-9:\-.]*\)+
-  \ skip=+<!--\_.\{-}-->+
-  \ end=+</\z1\_\s\{-}>+
-  \ end=+/>+
+" typescriptBlock seems to have been removed from the latest typescript-vim
+" syntax using @typescriptAll in it's place works (leaving typescriptBlock for
+" backwards compatiblity
+syn region tsxRegion contains=@XMLSyntax,tsxRegion,typesciptBlock,@typescriptAll
+  \ start="\%(<\|\w\)\@<!<\z([a-zA-Z][a-zA-Z0-9:\-.]*\)"
+  \ skip="<!--\_.\{-}-->"
+  \ end="</\z1\_\s\{-}>"
+  \ end="/>"
   \ keepend
   \ extend
 
 " TSX attributes should color as TS.  Note the trivial end pattern; we let
-" typescriptBlokc take care of ending the region.
-syn region xmlString contained start=+{+ end=++ contains=typescriptBlock
+" typescriptBlock or @typescriptAll take care of ending the region.
+syn region xmlString contained start="{" end="" contains=typescriptBlock,@typescriptAll
 
 " Add tsxRegion to the lowest-level TS syntax cluster.
 syn cluster typescriptExpression add=tsxRegion


### PR DESCRIPTION
In the current version of typescript-vim typescriptBlock is removed.

https://github.com/leafgarland/typescript-vim/blob/master/syntax/typescript.vim#L187

Adding @typescriptAll fixes the issue
